### PR TITLE
Using override instead of final

### DIFF
--- a/src/compute/cuda/cuda_device.hpp
+++ b/src/compute/cuda/cuda_device.hpp
@@ -44,33 +44,33 @@ public:
     cuda_device(int device);
     cuda_device(const cuda_device &other) = default;
     cuda_device(cuda_device &&other) = default;
-    virtual ~cuda_device() = default;
+    ~cuda_device() override = default;
 
     cuda_device& operator=(const cuda_device &other) = default;
     cuda_device& operator=(cuda_device &&other) = default;
 
-    std::unique_ptr<device_queue> create_queue() final;
-    std::shared_ptr<device_queue> create_queue_shared() final;
+    std::unique_ptr<device_queue> create_queue() override;
+    std::shared_ptr<device_queue> create_queue_shared() override;
 
     std::unique_ptr<device_memory_allocator>
-    create_device_memory_allocator() final;
+    create_device_memory_allocator() override;
     std::shared_ptr<device_memory_allocator>
-    create_device_memory_allocator_shared() final;
+    create_device_memory_allocator_shared() override;
 
     std::unique_ptr<host_memory_allocator>
-    create_host_memory_allocator() final;
+    create_host_memory_allocator() override;
     std::shared_ptr<host_memory_allocator>
-    create_host_memory_allocator_shared() final;
+    create_host_memory_allocator_shared() override;
 
     std::unique_ptr<host_to_device_transfer> 
-    create_host_to_device_transfer() final;
+    create_host_to_device_transfer() override;
     std::shared_ptr<host_to_device_transfer> 
-    create_host_to_device_transfer_shared() final;
+    create_host_to_device_transfer_shared() override;
 
     std::unique_ptr<device_to_host_transfer> 
-    create_device_to_host_transfer() final;
+    create_device_to_host_transfer() override;
     std::shared_ptr<device_to_host_transfer> 
-    create_device_to_host_transfer_shared() final;
+    create_device_to_host_transfer_shared() override;
 
 private:
     int m_device;

--- a/src/compute/cuda/cuda_device_backend.hpp
+++ b/src/compute/cuda/cuda_device_backend.hpp
@@ -43,15 +43,15 @@ class cuda_device_backend final
     : public device_backend
 {
 public:
-    const std::string& get_name() const noexcept final;
-    version get_version() const noexcept final;
-    bool is_available() const noexcept final;
+    const std::string& get_name() const noexcept override;
+    version get_version() const noexcept override;
+    bool is_available() const noexcept override;
 
-    void enumerate_devices(std::vector<std::size_t> &ids) const final;
-    bool get_device_properties(std::size_t id, device_properties &desc) const final;
+    void enumerate_devices(std::vector<std::size_t> &ids) const override;
+    bool get_device_properties(std::size_t id, device_properties &desc) const override;
 
-    std::unique_ptr<device> create_device(std::size_t id) final;
-    std::shared_ptr<device> create_device_shared(std::size_t id) final;
+    std::unique_ptr<device> create_device(std::size_t id) override;
+    std::shared_ptr<device> create_device_shared(std::size_t id) override;
 
     static bool register_at(device_manager &manager);
 

--- a/src/compute/cuda/cuda_device_memory_allocator.hpp
+++ b/src/compute/cuda/cuda_device_memory_allocator.hpp
@@ -55,7 +55,7 @@ public:
     explicit cuda_device_memory_allocator(int device_id);
     cuda_device_memory_allocator(const cuda_device_memory_allocator &other) = default;
     cuda_device_memory_allocator(cuda_device_memory_allocator &&other) = default;
-    virtual ~cuda_device_memory_allocator() = default;
+    ~cuda_device_memory_allocator() override = default;
 
     cuda_device_memory_allocator&
     operator=(const cuda_device_memory_allocator &other) = default;
@@ -64,12 +64,12 @@ public:
 
     std::unique_ptr<device_buffer> 
     create_buffer(numerical_type type, 
-                  std::size_t count, device_queue &queue ) final;
+                  std::size_t count, device_queue &queue ) override;
 
     std::shared_ptr<device_buffer> 
     create_buffer_shared(numerical_type type, 
                          std::size_t count, 
-                         device_queue &queue ) final;
+                         device_queue &queue ) override;
 
     const cuda_memory_block& allocate(numerical_type type, 
                                       std::size_t count,

--- a/src/compute/cuda/cuda_device_queue.hpp
+++ b/src/compute/cuda/cuda_device_queue.hpp
@@ -46,7 +46,7 @@ public:
     cuda_device_queue(int device);
     cuda_device_queue(const cuda_device_queue &other) = delete;
     cuda_device_queue(cuda_device_queue &&other) noexcept;
-    virtual ~cuda_device_queue();
+    ~cuda_device_queue() override;
 
     cuda_device_queue& operator=(const cuda_device_queue &other) = delete;
     cuda_device_queue& operator=(cuda_device_queue &&other) noexcept;
@@ -55,7 +55,7 @@ public:
     void reset() noexcept;
     handle get_handle() noexcept;
 
-    void synchronize() const final;
+    void synchronize() const override;
 
     std::size_t get_id() const noexcept;
 

--- a/src/compute/cuda/cuda_device_to_host_transfer.hpp
+++ b/src/compute/cuda/cuda_device_to_host_transfer.hpp
@@ -48,25 +48,25 @@ class cuda_device_to_host_transfer final
 public:
     void transfer_copy(const device_buffer &src_buffer, 
                        const std::shared_ptr<host_buffer> &dst_buffer, 
-                       device_queue &queue ) final;
+                       device_queue &queue ) override;
 
     void transfer_copy(const device_buffer &src_buffer,
                        const std::shared_ptr<host_buffer> &dst_buffer,
                        span<const copy_region> regions,
-                       device_queue &queue ) final;
+                       device_queue &queue ) override;
 
     std::shared_ptr<host_buffer> 
     transfer(const std::shared_ptr<device_buffer> &buffer, 
              host_memory_allocator &allocator,
-             device_queue &queue ) final;
+             device_queue &queue ) override;
 
     std::shared_ptr<const host_buffer> 
     transfer(const std::shared_ptr<const device_buffer> &buffer, 
              host_memory_allocator &allocator,
-             device_queue &queue ) final;
+             device_queue &queue ) override;
 
 
-    void wait() final;
+    void wait() override;
 
 private:
     cuda_device_event m_event;

--- a/src/compute/cuda/cuda_host_memory_allocator.hpp
+++ b/src/compute/cuda/cuda_host_memory_allocator.hpp
@@ -48,7 +48,7 @@ public:
     cuda_host_memory_allocator() = default;
     cuda_host_memory_allocator(const cuda_host_memory_allocator &other) = delete;
     cuda_host_memory_allocator(cuda_host_memory_allocator &&other) = delete;
-    virtual ~cuda_host_memory_allocator() = default;
+    ~cuda_host_memory_allocator() override = default;
 
     cuda_host_memory_allocator&
     operator=(const cuda_host_memory_allocator &other) = delete;
@@ -57,11 +57,11 @@ public:
 
     std::unique_ptr<host_buffer> 
     create_buffer(numerical_type type, 
-                  std::size_t count ) final;
+                  std::size_t count ) override;
 
     std::shared_ptr<host_buffer> 
     create_buffer_shared(numerical_type type, 
-                         std::size_t count ) final;
+                         std::size_t count ) override;
     
     const cuda_memory_block& allocate(numerical_type type, std::size_t count);
     void deallocate(const cuda_memory_block &block);

--- a/src/compute/cuda/cuda_host_to_device_transfer.hpp
+++ b/src/compute/cuda/cuda_host_to_device_transfer.hpp
@@ -48,26 +48,26 @@ class cuda_host_to_device_transfer final
 public:
     void transfer_copy(const std::shared_ptr<const host_buffer> &src_buffer, 
                        device_buffer &dst_buffer, 
-                       device_queue &queue ) final;
+                       device_queue &queue ) override;
 
     void transfer_copy(const std::shared_ptr<const host_buffer> &src_buffer, 
                        device_buffer &dst_buffer, 
                        span<const copy_region> regions,
-                       device_queue &queue ) final;
+                       device_queue &queue ) override;
 
     std::shared_ptr<device_buffer> 
     transfer(const std::shared_ptr<host_buffer> &buffer, 
              device_memory_allocator &allocator,
-             device_queue &queue ) final;
+             device_queue &queue ) override;
 
     std::shared_ptr<const device_buffer> 
     transfer(const std::shared_ptr<const host_buffer> &buffer, 
              device_memory_allocator &allocator,
-             device_queue &queue ) final;
+             device_queue &queue ) override;
 
 
-    void wait() final;
-    void wait(device_queue &queue) final;
+    void wait() override;
+    void wait(device_queue &queue) override;
 
 private:
     cuda_device_event m_event;

--- a/src/compute/cuda/default_cuda_device_buffer.hpp
+++ b/src/compute/cuda/default_cuda_device_buffer.hpp
@@ -54,7 +54,7 @@ public:
                                cuda_device_memory_allocator &allocator ) noexcept;
     default_cuda_device_buffer(const default_cuda_device_buffer &other) = delete;
     default_cuda_device_buffer(default_cuda_device_buffer &&other) noexcept;
-    ~default_cuda_device_buffer() final;
+    ~default_cuda_device_buffer() override;
 
     default_cuda_device_buffer& 
     operator=(const default_cuda_device_buffer &other) = delete;
@@ -64,11 +64,11 @@ public:
     void swap(default_cuda_device_buffer &other) noexcept;
     void reset() noexcept;
 
-    numerical_type get_type() const noexcept final;
-    std::size_t get_count() const noexcept final;
+    numerical_type get_type() const noexcept override;
+    std::size_t get_count() const noexcept override;
 
-    void* get_data() noexcept final;
-    const void* get_data() const noexcept final;
+    void* get_data() noexcept override;
+    const void* get_data() const noexcept override;
 
     void record_queue(cuda_device_queue &queue);
 

--- a/src/compute/cuda/default_cuda_host_buffer.hpp
+++ b/src/compute/cuda/default_cuda_host_buffer.hpp
@@ -51,7 +51,7 @@ public:
                              cuda_host_memory_allocator &allocator) noexcept;
     default_cuda_host_buffer(const default_cuda_host_buffer &other) = delete;
     default_cuda_host_buffer(default_cuda_host_buffer &&other) noexcept;
-    ~default_cuda_host_buffer() final;
+    ~default_cuda_host_buffer() override;
 
     default_cuda_host_buffer& 
     operator=(const default_cuda_host_buffer &other) = delete;
@@ -61,11 +61,11 @@ public:
     void swap(default_cuda_host_buffer &other) noexcept;
     void reset() noexcept;
 
-    numerical_type get_type() const noexcept final;
-    std::size_t get_count() const noexcept final;
+    numerical_type get_type() const noexcept override;
+    std::size_t get_count() const noexcept override;
 
-    void* get_data() noexcept final;
-    const void* get_data() const noexcept final;
+    void* get_data() noexcept override;
+    const void* get_data() const noexcept override;
 
 private:
     numerical_type m_type;

--- a/src/cuda_plugin.hpp
+++ b/src/cuda_plugin.hpp
@@ -41,7 +41,7 @@ public:
     cuda_plugin() = default;
     cuda_plugin(const cuda_plugin& other) = default;
     cuda_plugin(cuda_plugin&& other) = default;
-    virtual ~cuda_plugin() = default;
+    ~cuda_plugin() override = default;
 
     cuda_plugin& operator=(const cuda_plugin& other) = default;
     cuda_plugin& operator=(cuda_plugin&& other) = default;


### PR DESCRIPTION
Changed my mind about a codesmell marked "False-positive" in sonar cloud:
- When declaring a class as final, codesmell suggests using override on overriden methods (I was using final earlier). For this particular case, both keywords are equivalent, but now I prefer to adhere to the Sonar Cloud suggestion