### PR TITLE
Fix compilation warning

### DIFF
--- a/src/compute/cuda_event.cpp
+++ b/src/compute/cuda_event.cpp
@@ -126,6 +126,7 @@ bool cuda_event::is_signaled() const
     
     default:
         XMIPP4_CUDA_CHECK(code);
+        result = false; // To avoid warnings. The above line should throw.
         break;
     }
     return result;


### PR DESCRIPTION
The warning is a false positive, but adding a line to prevent from this appearing.