### PR TITLE
Add spdlog build flag to core install action

### DIFF
--- a/.github/composites/install-xmipp4-core/action.yml
+++ b/.github/composites/install-xmipp4-core/action.yml
@@ -37,6 +37,7 @@ runs:
         options: |
           BUILD_TESTING=OFF
           CMAKE_BUILD_TYPE=Release
+          XMIPP4_CORE_BUILD_SPDLOG=ON
         run-build: true
         build-args: --config ${{ env.BUILD_TYPE }}
 


### PR DESCRIPTION
This flag needs to be specified as spdlog is not installed in the system