### PR TITLE
Disable testing in pip by default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,10 +55,11 @@ Homepage = "https://github.com/gigabit-clowns/xmipp4-compute-cuda"
 
 [tool.scikit-build]
 experimental=true # For wheel.install-dir
+wheel.install-dir="/data"
 cmake.version = ">=3.16"
 cmake.args = []
-cmake.define = {}
 cmake.verbose = false
 cmake.build-type = "Release"
 
-wheel.install-dir="/data"
+[tool.scikit-build.cmake.define]
+BUILD_TESTING = "OFF"


### PR DESCRIPTION
Speeds up compile times. Can be disabled by passing `-Ccmake.define.BUILD_TESTING=ON` to pip