### PR TITLE
Substitute verbose headers with SPDX identifier for lincense

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,25 +1,3 @@
-#***************************************************************************
-# Authors:     Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-# 02111-1307  USA
-#
-#  All comments concerning this program package may be sent to the
-#  e-mail address 'xmipp@cnb.csic.es'
-# ***************************************************************************
-
 cmake_minimum_required(VERSION 3.18)
 
 # Define the project

--- a/conda/bld.bat
+++ b/conda/bld.bat
@@ -1,24 +1,2 @@
-::***************************************************************************
-:: Authors:     Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
-::
-:: This program is free software; you can redistribute it and/or modify
-:: it under the terms of the GNU General Public License as published by
-:: the Free Software Foundation; either version 2 of the License, or
-:: (at your option) any later version.
-::
-:: This program is distributed in the hope that it will be useful,
-:: but WITHOUT ANY WARRANTY; without even the implied warranty of
-:: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-:: GNU General Public License for more details.
-::
-:: You should have received a copy of the GNU General Public License
-:: along with this program; if not, write to the Free Software
-:: Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-:: 02111-1307  USA
-::
-::  All comments concerning this program package may be sent to the
-::  e-mail address 'xmipp@cnb.csic.es'
-:: ***************************************************************************
-
 python -m pip install . -vvv --no-deps
 exit errorlevel

--- a/conda/build.sh
+++ b/conda/build.sh
@@ -1,27 +1,5 @@
 #!/bin/sh
 
-#***************************************************************************
-# Authors:     Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-# 02111-1307  USA
-#
-#  All comments concerning this program package may be sent to the
-#  e-mail address 'xmipp@cnb.csic.es'
-# ***************************************************************************
-
 # https://conda-forge.org/docs/maintainer/knowledge_base.html#newer-c-features-with-old-sdk
 export CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
 

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,25 +1,3 @@
-#***************************************************************************
-# Authors:     Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-# 02111-1307  USA
-#
-#  All comments concerning this program package may be sent to the
-#  e-mail address 'xmipp@cnb.csic.es'
-# ***************************************************************************
-
 # File based on:
 # https://github.com/pybind/cmake_example/blob/master/conda.recipe/meta.yaml
 # https://scikit-build-core.readthedocs.io/en/stable/faqs.html#making-a-conda-recipe

--- a/include/xmipp4/cuda/compute/allocator/cuda_caching_memory_allocator.hpp
+++ b/include/xmipp4/cuda/compute/allocator/cuda_caching_memory_allocator.hpp
@@ -1,25 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
 #pragma once
-
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
-
 #include "cuda_memory_block_cache.hpp"
 
 #include <xmipp4/core/platform/attributes.hpp>

--- a/include/xmipp4/cuda/compute/allocator/cuda_caching_memory_allocator.hpp
+++ b/include/xmipp4/cuda/compute/allocator/cuda_caching_memory_allocator.hpp
@@ -20,14 +20,6 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 
-/**
- * @file cuda_caching_memory_allocator.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines cuda_caching_memory_allocator
- * @date 2024-11-28
- * 
- */
-
 #include "cuda_memory_block_cache.hpp"
 
 #include <xmipp4/core/platform/attributes.hpp>

--- a/include/xmipp4/cuda/compute/allocator/cuda_caching_memory_allocator.inl
+++ b/include/xmipp4/cuda/compute/allocator/cuda_caching_memory_allocator.inl
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 #include "cuda_caching_memory_allocator.hpp"
 

--- a/include/xmipp4/cuda/compute/allocator/cuda_caching_memory_allocator.inl
+++ b/include/xmipp4/cuda/compute/allocator/cuda_caching_memory_allocator.inl
@@ -18,14 +18,6 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 
-/**
- * @file cuda_deferred_release.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of cuda_deferred_release.hpp
- * @date 2024-11-28
- * 
- */
-
 #include "cuda_caching_memory_allocator.hpp"
 
 #include <new>

--- a/include/xmipp4/cuda/compute/allocator/cuda_deferred_memory_block_release.hpp
+++ b/include/xmipp4/cuda/compute/allocator/cuda_deferred_memory_block_release.hpp
@@ -20,14 +20,6 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 
-/**
- * @file cuda_deferred_memory_block_release.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines data structure representing a memory cache.
- * @date 2024-11-28
- * 
- */
-
 #include "cuda_memory_block.hpp"
 #include "cuda_memory_block_pool.hpp"
 #include "../cuda_event.hpp"

--- a/include/xmipp4/cuda/compute/allocator/cuda_deferred_memory_block_release.hpp
+++ b/include/xmipp4/cuda/compute/allocator/cuda_deferred_memory_block_release.hpp
@@ -1,25 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
 #pragma once
-
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
-
 #include "cuda_memory_block.hpp"
 #include "cuda_memory_block_pool.hpp"
 #include "../cuda_event.hpp"

--- a/include/xmipp4/cuda/compute/allocator/cuda_deferred_memory_block_release.inl
+++ b/include/xmipp4/cuda/compute/allocator/cuda_deferred_memory_block_release.inl
@@ -18,14 +18,6 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 
-/**
- * @file cuda_deferred_memory_block_release.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of cuda_deferred_memory_block_release.hpp
- * @date 2024-11-28
- * 
- */
-
 #include "cuda_deferred_memory_block_release.hpp"
 
 #include <algorithm>

--- a/include/xmipp4/cuda/compute/allocator/cuda_deferred_memory_block_release.inl
+++ b/include/xmipp4/cuda/compute/allocator/cuda_deferred_memory_block_release.inl
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 #include "cuda_deferred_memory_block_release.hpp"
 

--- a/include/xmipp4/cuda/compute/allocator/cuda_device_malloc.hpp
+++ b/include/xmipp4/cuda/compute/allocator/cuda_device_malloc.hpp
@@ -20,14 +20,6 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 
-/**
- * @file cuda_device_malloc.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines cuda_device_malloc class.
- * @date 2024-11-06
- * 
- */
-
 #include <cstddef>
 
 namespace xmipp4 

--- a/include/xmipp4/cuda/compute/allocator/cuda_device_malloc.hpp
+++ b/include/xmipp4/cuda/compute/allocator/cuda_device_malloc.hpp
@@ -1,25 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
 #pragma once
-
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
-
 #include <cstddef>
 
 namespace xmipp4 

--- a/include/xmipp4/cuda/compute/allocator/cuda_device_malloc.inl
+++ b/include/xmipp4/cuda/compute/allocator/cuda_device_malloc.inl
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 #include "../cuda_error.hpp"
 #include "cuda_device_malloc.hpp"

--- a/include/xmipp4/cuda/compute/allocator/cuda_device_malloc.inl
+++ b/include/xmipp4/cuda/compute/allocator/cuda_device_malloc.inl
@@ -18,14 +18,6 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 
-/**
- * @file cuda_device_malloc.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of cuda_device_malloc.hpp
- * @date 2024-11-06
- * 
- */
-
 #include "../cuda_error.hpp"
 #include "cuda_device_malloc.hpp"
 

--- a/include/xmipp4/cuda/compute/allocator/cuda_host_malloc.hpp
+++ b/include/xmipp4/cuda/compute/allocator/cuda_host_malloc.hpp
@@ -1,25 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
 #pragma once
-
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
-
 #include <cstddef>
 
 /**

--- a/include/xmipp4/cuda/compute/allocator/cuda_host_malloc.hpp
+++ b/include/xmipp4/cuda/compute/allocator/cuda_host_malloc.hpp
@@ -20,14 +20,6 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 
-/**
- * @file cuda_host_malloc.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines cuda_host_malloc class.
- * @date 2024-11-06
- * 
- */
-
 #include <cstddef>
 
 /**

--- a/include/xmipp4/cuda/compute/allocator/cuda_host_malloc.inl
+++ b/include/xmipp4/cuda/compute/allocator/cuda_host_malloc.inl
@@ -18,14 +18,6 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 
-/**
- * @file cuda_host_malloc.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of cuda_host_malloc.hpp
- * @date 2024-11-06
- * 
- */
-
 #include "../cuda_error.hpp"
 #include "cuda_host_malloc.hpp"
 

--- a/include/xmipp4/cuda/compute/allocator/cuda_host_malloc.inl
+++ b/include/xmipp4/cuda/compute/allocator/cuda_host_malloc.inl
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 #include "../cuda_error.hpp"
 #include "cuda_host_malloc.hpp"

--- a/include/xmipp4/cuda/compute/allocator/cuda_memory_allocator_delete.hpp
+++ b/include/xmipp4/cuda/compute/allocator/cuda_memory_allocator_delete.hpp
@@ -20,14 +20,6 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 
-/**
- * @file cuda_memory_allocator_delete.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines the cuda_memory_allocator_delete.hpp class
- * @date 2024-11-29
- * 
- */
-
 #include <functional>
 
 namespace xmipp4

--- a/include/xmipp4/cuda/compute/allocator/cuda_memory_allocator_delete.hpp
+++ b/include/xmipp4/cuda/compute/allocator/cuda_memory_allocator_delete.hpp
@@ -1,25 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
 #pragma once
-
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
-
 #include <functional>
 
 namespace xmipp4

--- a/include/xmipp4/cuda/compute/allocator/cuda_memory_allocator_delete.inl
+++ b/include/xmipp4/cuda/compute/allocator/cuda_memory_allocator_delete.inl
@@ -18,14 +18,6 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 
-/**
- * @file cuda_memory_block_cache.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of cuda_memory_block_cache.hpp
- * @date 2024-11-28
- * 
- */
-
 #include "cuda_memory_allocator_delete.hpp"
 
 namespace xmipp4

--- a/include/xmipp4/cuda/compute/allocator/cuda_memory_allocator_delete.inl
+++ b/include/xmipp4/cuda/compute/allocator/cuda_memory_allocator_delete.inl
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 #include "cuda_memory_allocator_delete.hpp"
 

--- a/include/xmipp4/cuda/compute/allocator/cuda_memory_block.hpp
+++ b/include/xmipp4/cuda/compute/allocator/cuda_memory_block.hpp
@@ -1,25 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
 #pragma once
-
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
-
 #include <xmipp4/core/span.hpp>
 
 #include <cstddef>

--- a/include/xmipp4/cuda/compute/allocator/cuda_memory_block.hpp
+++ b/include/xmipp4/cuda/compute/allocator/cuda_memory_block.hpp
@@ -20,14 +20,6 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 
-/**
- * @file cuda_memory_block.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines data structure representing a memory block.
- * @date 2024-11-06
- * 
- */
-
 #include <xmipp4/core/span.hpp>
 
 #include <cstddef>

--- a/include/xmipp4/cuda/compute/allocator/cuda_memory_block.inl
+++ b/include/xmipp4/cuda/compute/allocator/cuda_memory_block.inl
@@ -18,14 +18,6 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 
-/**
- * @file cuda_memory_block.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of cuda_memory_block.hpp
- * @date 2024-11-06
- * 
- */
-
 #include "cuda_memory_block.hpp"
 
 #include <xmipp4/core/memory/align.hpp>

--- a/include/xmipp4/cuda/compute/allocator/cuda_memory_block.inl
+++ b/include/xmipp4/cuda/compute/allocator/cuda_memory_block.inl
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 #include "cuda_memory_block.hpp"
 

--- a/include/xmipp4/cuda/compute/allocator/cuda_memory_block_cache.hpp
+++ b/include/xmipp4/cuda/compute/allocator/cuda_memory_block_cache.hpp
@@ -1,25 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
 #pragma once
-
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
-
 #include "cuda_memory_block.hpp"
 #include "cuda_memory_block_pool.hpp"
 #include "cuda_deferred_memory_block_release.hpp"

--- a/include/xmipp4/cuda/compute/allocator/cuda_memory_block_cache.hpp
+++ b/include/xmipp4/cuda/compute/allocator/cuda_memory_block_cache.hpp
@@ -20,14 +20,6 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 
-/**
- * @file cuda_memory_block_cache.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines data structure representing a memory cache.
- * @date 2024-11-28
- * 
- */
-
 #include "cuda_memory_block.hpp"
 #include "cuda_memory_block_pool.hpp"
 #include "cuda_deferred_memory_block_release.hpp"

--- a/include/xmipp4/cuda/compute/allocator/cuda_memory_block_cache.inl
+++ b/include/xmipp4/cuda/compute/allocator/cuda_memory_block_cache.inl
@@ -18,14 +18,6 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 
-/**
- * @file cuda_memory_block_cache.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of cuda_memory_block_cache.hpp
- * @date 2024-11-28
- * 
- */
-
 #include "cuda_memory_block_cache.hpp"
 
 #include <stdexcept>

--- a/include/xmipp4/cuda/compute/allocator/cuda_memory_block_cache.inl
+++ b/include/xmipp4/cuda/compute/allocator/cuda_memory_block_cache.inl
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 #include "cuda_memory_block_cache.hpp"
 

--- a/include/xmipp4/cuda/compute/allocator/cuda_memory_block_pool.hpp
+++ b/include/xmipp4/cuda/compute/allocator/cuda_memory_block_pool.hpp
@@ -1,25 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
 #pragma once
-
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
-
 #include "cuda_memory_block.hpp"
 #include "cuda_memory_block_usage_tracker.hpp"
 

--- a/include/xmipp4/cuda/compute/allocator/cuda_memory_block_pool.hpp
+++ b/include/xmipp4/cuda/compute/allocator/cuda_memory_block_pool.hpp
@@ -20,14 +20,6 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 
-/**
- * @file cuda_memory_block_pool.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines memory allocation caching data structures.
- * @date 2024-11-04
- * 
- */
-
 #include "cuda_memory_block.hpp"
 #include "cuda_memory_block_usage_tracker.hpp"
 

--- a/include/xmipp4/cuda/compute/allocator/cuda_memory_block_pool.inl
+++ b/include/xmipp4/cuda/compute/allocator/cuda_memory_block_pool.inl
@@ -18,14 +18,6 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 
-/**
- * @file cuda_memory_block_pool.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of cuda_memory_block_pool.hpp
- * @date 2024-11-04
- * 
- */
-
 #include "cuda_memory_block_pool.hpp"
 
 #include <xmipp4/core/memory/align.hpp>

--- a/include/xmipp4/cuda/compute/allocator/cuda_memory_block_pool.inl
+++ b/include/xmipp4/cuda/compute/allocator/cuda_memory_block_pool.inl
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 #include "cuda_memory_block_pool.hpp"
 

--- a/include/xmipp4/cuda/compute/allocator/cuda_memory_block_usage_tracker.hpp
+++ b/include/xmipp4/cuda/compute/allocator/cuda_memory_block_usage_tracker.hpp
@@ -1,25 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
 #pragma once
-
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
-
 #include "cuda_memory_block.hpp"
 
 #include <xmipp4/core/span.hpp>

--- a/include/xmipp4/cuda/compute/allocator/cuda_memory_block_usage_tracker.hpp
+++ b/include/xmipp4/cuda/compute/allocator/cuda_memory_block_usage_tracker.hpp
@@ -20,14 +20,6 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 
-/**
- * @file cuda_memory_block_usage_tracker.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines data structure representing a memory block.
- * @date 2024-11-30
- * 
- */
-
 #include "cuda_memory_block.hpp"
 
 #include <xmipp4/core/span.hpp>

--- a/include/xmipp4/cuda/compute/allocator/cuda_memory_block_usage_tracker.inl
+++ b/include/xmipp4/cuda/compute/allocator/cuda_memory_block_usage_tracker.inl
@@ -18,14 +18,6 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 
-/**
- * @file cuda_memory_block_usage_tracker.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of cuda_memory_block_usage_tracker.hpp
- * @date 2024-11-30
- * 
- */
-
 #include "cuda_memory_block_usage_tracker.hpp"
 
 #include <algorithm>

--- a/include/xmipp4/cuda/compute/allocator/cuda_memory_block_usage_tracker.inl
+++ b/include/xmipp4/cuda/compute/allocator/cuda_memory_block_usage_tracker.inl
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 #include "cuda_memory_block_usage_tracker.hpp"
 

--- a/include/xmipp4/cuda/compute/cuda_device.hpp
+++ b/include/xmipp4/cuda/compute/cuda_device.hpp
@@ -20,14 +20,6 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 
-/**
- * @file cuda_device.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines cuda_device class.
- * @date 2024-10-30
- * 
- */
-
 #include <xmipp4/core/compute/device.hpp>
 
 #include "cuda_device_queue_pool.hpp"

--- a/include/xmipp4/cuda/compute/cuda_device.hpp
+++ b/include/xmipp4/cuda/compute/cuda_device.hpp
@@ -1,25 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
 #pragma once
-
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
-
 #include <xmipp4/core/compute/device.hpp>
 
 #include "cuda_device_queue_pool.hpp"

--- a/include/xmipp4/cuda/compute/cuda_device_backend.hpp
+++ b/include/xmipp4/cuda/compute/cuda_device_backend.hpp
@@ -1,25 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
 #pragma once
-
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
-
 /**
  * @file cuda_device_backend.hpp
  * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)

--- a/include/xmipp4/cuda/compute/cuda_device_backend.hpp
+++ b/include/xmipp4/cuda/compute/cuda_device_backend.hpp
@@ -1,13 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 #pragma once
-/**
- * @file cuda_device_backend.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines cuda_device_backend interface
- * @date 2024-10-31
- * 
- */
 
 #include <xmipp4/core/compute/device_backend.hpp>
 #include <xmipp4/core/compute/device_create_parameters.hpp>

--- a/include/xmipp4/cuda/compute/cuda_device_buffer.hpp
+++ b/include/xmipp4/cuda/compute/cuda_device_buffer.hpp
@@ -1,25 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
 #pragma once
-
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
-
 #include <xmipp4/core/compute/device_buffer.hpp>
 
 namespace xmipp4 

--- a/include/xmipp4/cuda/compute/cuda_device_buffer.hpp
+++ b/include/xmipp4/cuda/compute/cuda_device_buffer.hpp
@@ -20,14 +20,6 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 
-/**
- * @file cuda_device_buffer.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines the compute::cuda_device_buffer interface
- * @date 2024-10-30
- * 
- */
-
 #include <xmipp4/core/compute/device_buffer.hpp>
 
 namespace xmipp4 

--- a/include/xmipp4/cuda/compute/cuda_device_copy.hpp
+++ b/include/xmipp4/cuda/compute/cuda_device_copy.hpp
@@ -1,25 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
 #pragma once
-
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
-
 #include <xmipp4/core/compute/device_copy.hpp>
 
 namespace xmipp4 

--- a/include/xmipp4/cuda/compute/cuda_device_copy.hpp
+++ b/include/xmipp4/cuda/compute/cuda_device_copy.hpp
@@ -20,14 +20,6 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 
-/**
- * @file cuda_device_copy.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines the compute::cuda_device_copy class
- * @date 2024-11-15
- * 
- */
-
 #include <xmipp4/core/compute/device_copy.hpp>
 
 namespace xmipp4 

--- a/include/xmipp4/cuda/compute/cuda_device_memory_allocator.hpp
+++ b/include/xmipp4/cuda/compute/cuda_device_memory_allocator.hpp
@@ -20,14 +20,6 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 
-/**
- * @file cuda_device_memory_allocator.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines the compute::cuda_device_memory_allocator interface
- * @date 2024-10-31
- * 
- */
-
 #include "allocator/cuda_device_malloc.hpp"
 #include "allocator/cuda_caching_memory_allocator.hpp"
 

--- a/include/xmipp4/cuda/compute/cuda_device_memory_allocator.hpp
+++ b/include/xmipp4/cuda/compute/cuda_device_memory_allocator.hpp
@@ -1,25 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
 #pragma once
-
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
-
 #include "allocator/cuda_device_malloc.hpp"
 #include "allocator/cuda_caching_memory_allocator.hpp"
 

--- a/include/xmipp4/cuda/compute/cuda_device_queue.hpp
+++ b/include/xmipp4/cuda/compute/cuda_device_queue.hpp
@@ -1,25 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
 #pragma once
-
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
-
 #include <xmipp4/core/compute/device_queue.hpp>
 
 #include <cuda_runtime.h>

--- a/include/xmipp4/cuda/compute/cuda_device_queue.hpp
+++ b/include/xmipp4/cuda/compute/cuda_device_queue.hpp
@@ -20,14 +20,6 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 
-/**
- * @file cuda_device_queue.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines cuda_device_queue class.
- * @date 2024-10-30
- * 
- */
-
 #include <xmipp4/core/compute/device_queue.hpp>
 
 #include <cuda_runtime.h>

--- a/include/xmipp4/cuda/compute/cuda_device_queue_pool.hpp
+++ b/include/xmipp4/cuda/compute/cuda_device_queue_pool.hpp
@@ -1,25 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
 #pragma once
-
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
-
 #include <xmipp4/core/compute/device_queue_pool.hpp>
 
 #include "cuda_device_queue.hpp"

--- a/include/xmipp4/cuda/compute/cuda_device_queue_pool.hpp
+++ b/include/xmipp4/cuda/compute/cuda_device_queue_pool.hpp
@@ -20,14 +20,6 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 
-/**
- * @file cuda_device_queue.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines cuda_device_queue interface
- * @date 2024-11-27
- * 
- */
-
 #include <xmipp4/core/compute/device_queue_pool.hpp>
 
 #include "cuda_device_queue.hpp"

--- a/include/xmipp4/cuda/compute/cuda_device_to_host_transfer.hpp
+++ b/include/xmipp4/cuda/compute/cuda_device_to_host_transfer.hpp
@@ -1,25 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
 #pragma once
-
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
-
 #include <xmipp4/core/compute/device_to_host_transfer.hpp>
 
 #include "cuda_event.hpp"

--- a/include/xmipp4/cuda/compute/cuda_device_to_host_transfer.hpp
+++ b/include/xmipp4/cuda/compute/cuda_device_to_host_transfer.hpp
@@ -20,14 +20,6 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 
-/**
- * @file cuda_device_to_host_transfer.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines the compute::cuda_device_to_host_transfer class
- * @date 2024-11-06
- * 
- */
-
 #include <xmipp4/core/compute/device_to_host_transfer.hpp>
 
 #include "cuda_event.hpp"

--- a/include/xmipp4/cuda/compute/cuda_error.hpp
+++ b/include/xmipp4/cuda/compute/cuda_error.hpp
@@ -1,25 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
 #pragma once
-
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
-
 #include <stdexcept>
 
 #include <cuda_runtime.h>

--- a/include/xmipp4/cuda/compute/cuda_error.hpp
+++ b/include/xmipp4/cuda/compute/cuda_error.hpp
@@ -20,14 +20,6 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 
-/**
- * @file cuda_error.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines a cuda error exception and methods that throw it.
- * @date 2024-11-17
- * 
- */
-
 #include <stdexcept>
 
 #include <cuda_runtime.h>

--- a/include/xmipp4/cuda/compute/cuda_event.hpp
+++ b/include/xmipp4/cuda/compute/cuda_event.hpp
@@ -1,25 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
 #pragma once
-
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
-
 #include <xmipp4/core/compute/device_event.hpp>
 #include <xmipp4/core/compute/device_to_host_event.hpp>
 

--- a/include/xmipp4/cuda/compute/cuda_event.hpp
+++ b/include/xmipp4/cuda/compute/cuda_event.hpp
@@ -20,14 +20,6 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 
-/**
- * @file cuda_event.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines cuda_event class.
- * @date 2024-11-13
- * 
- */
-
 #include <xmipp4/core/compute/device_event.hpp>
 #include <xmipp4/core/compute/device_to_host_event.hpp>
 

--- a/include/xmipp4/cuda/compute/cuda_host_memory_allocator.hpp
+++ b/include/xmipp4/cuda/compute/cuda_host_memory_allocator.hpp
@@ -1,25 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
 #pragma once
-
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
-
 #include "allocator/cuda_host_malloc.hpp"
 #include "allocator/cuda_caching_memory_allocator.hpp"
 

--- a/include/xmipp4/cuda/compute/cuda_host_memory_allocator.hpp
+++ b/include/xmipp4/cuda/compute/cuda_host_memory_allocator.hpp
@@ -20,14 +20,6 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 
-/**
- * @file cuda_host_memory_allocator.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines the compute::cuda_host_memory_allocator interface
- * @date 2024-11-06
- * 
- */
-
 #include "allocator/cuda_host_malloc.hpp"
 #include "allocator/cuda_caching_memory_allocator.hpp"
 

--- a/include/xmipp4/cuda/compute/cuda_host_to_device_transfer.hpp
+++ b/include/xmipp4/cuda/compute/cuda_host_to_device_transfer.hpp
@@ -20,14 +20,6 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 
-/**
- * @file cuda_host_to_device_transfer.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines the compute::cuda_host_to_device_transfer class
- * @date 2024-11-06
- * 
- */
-
 #include <xmipp4/core/compute/host_to_device_transfer.hpp>
 
 #include "cuda_event.hpp"

--- a/include/xmipp4/cuda/compute/cuda_host_to_device_transfer.hpp
+++ b/include/xmipp4/cuda/compute/cuda_host_to_device_transfer.hpp
@@ -1,25 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
 #pragma once
-
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
-
 #include <xmipp4/core/compute/host_to_device_transfer.hpp>
 
 #include "cuda_event.hpp"

--- a/src/compute/cuda_buffer_memcpy.cpp
+++ b/src/compute/cuda_buffer_memcpy.cpp
@@ -18,14 +18,6 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 
-/**
- * @file cuda_buffer_memcpy.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of cuda_buffer_memcpy.hpp
- * @date 2024-12-07
- * 
- */
-
 #include "cuda_buffer_memcpy.hpp"
 
 #include <xmipp4/cuda/compute/cuda_error.hpp>

--- a/src/compute/cuda_buffer_memcpy.cpp
+++ b/src/compute/cuda_buffer_memcpy.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 #include "cuda_buffer_memcpy.hpp"
 

--- a/src/compute/cuda_buffer_memcpy.hpp
+++ b/src/compute/cuda_buffer_memcpy.hpp
@@ -20,14 +20,6 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 
-/**
- * @file cuda_buffer_memcpy.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines functions to copy between cuda buffers
- * @date 2024-12-07
- * 
- */
-
 #include <xmipp4/core/span.hpp>
 
 namespace xmipp4 

--- a/src/compute/cuda_buffer_memcpy.hpp
+++ b/src/compute/cuda_buffer_memcpy.hpp
@@ -1,25 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
 #pragma once
-
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
-
 #include <xmipp4/core/span.hpp>
 
 namespace xmipp4 

--- a/src/compute/cuda_device.cpp
+++ b/src/compute/cuda_device.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 #include <xmipp4/cuda/compute/cuda_device.hpp>
 

--- a/src/compute/cuda_device.cpp
+++ b/src/compute/cuda_device.cpp
@@ -18,14 +18,6 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 
-/**
- * @file cuda_device.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of cuda_device.hpp
- * @date 2024-10-30
- * 
- */
-
 #include <xmipp4/cuda/compute/cuda_device.hpp>
 
 #include <xmipp4/cuda/compute/cuda_device_queue.hpp>

--- a/src/compute/cuda_device_backend.cpp
+++ b/src/compute/cuda_device_backend.cpp
@@ -18,14 +18,6 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 
-/**
- * @file cuda_device_backend.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of cuda_device_backend.hpp
- * @date 2024-10-30
- * 
- */
-
 #include <xmipp4/cuda/compute/cuda_device_backend.hpp>
 
 #include <xmipp4/cuda/compute/cuda_error.hpp>

--- a/src/compute/cuda_device_backend.cpp
+++ b/src/compute/cuda_device_backend.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 #include <xmipp4/cuda/compute/cuda_device_backend.hpp>
 

--- a/src/compute/cuda_device_copy.cpp
+++ b/src/compute/cuda_device_copy.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 #include <xmipp4/cuda/compute/cuda_device_copy.hpp>
 

--- a/src/compute/cuda_device_copy.cpp
+++ b/src/compute/cuda_device_copy.cpp
@@ -18,14 +18,6 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 
-/**
- * @file cuda_device_copy.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of cuda_device_buffer_copy.hpp
- * @date 2024-11-06
- * 
- */
-
 #include <xmipp4/cuda/compute/cuda_device_copy.hpp>
 
 #include <xmipp4/cuda/compute/cuda_device_queue.hpp>

--- a/src/compute/cuda_device_memory_allocator.cpp
+++ b/src/compute/cuda_device_memory_allocator.cpp
@@ -18,14 +18,6 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 
-/**
- * @file cuda_device_memory_allocator.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of cuda_device_memory_allocator.hpp
- * @date 2024-11-06
- * 
- */
-
 #include <xmipp4/cuda/compute/cuda_device_memory_allocator.hpp>
 
 #include "default_cuda_device_buffer.hpp"

--- a/src/compute/cuda_device_memory_allocator.cpp
+++ b/src/compute/cuda_device_memory_allocator.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 #include <xmipp4/cuda/compute/cuda_device_memory_allocator.hpp>
 

--- a/src/compute/cuda_device_queue.cpp
+++ b/src/compute/cuda_device_queue.cpp
@@ -18,14 +18,6 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 
-/**
- * @file cuda_device_queue.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of cuda_device_queue.hpp
- * @date 2024-10-30
- * 
- */
-
 #include <xmipp4/cuda/compute/cuda_device_queue.hpp>
 
 #include <xmipp4/cuda/compute/cuda_error.hpp>

--- a/src/compute/cuda_device_queue.cpp
+++ b/src/compute/cuda_device_queue.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 #include <xmipp4/cuda/compute/cuda_device_queue.hpp>
 

--- a/src/compute/cuda_device_queue_pool.cpp
+++ b/src/compute/cuda_device_queue_pool.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 #include <xmipp4/cuda/compute/cuda_device_queue_pool.hpp>
 

--- a/src/compute/cuda_device_queue_pool.cpp
+++ b/src/compute/cuda_device_queue_pool.cpp
@@ -18,14 +18,6 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 
-/**
- * @file cuda_device_queue.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of cuda_device_queue.hpp
- * @date 2024-11-27
- * 
- */
-
 #include <xmipp4/cuda/compute/cuda_device_queue_pool.hpp>
 
 #include <xmipp4/cuda/compute/cuda_error.hpp>

--- a/src/compute/cuda_device_to_host_transfer.cpp
+++ b/src/compute/cuda_device_to_host_transfer.cpp
@@ -18,14 +18,6 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 
-/**
- * @file cuda_device_to_host_transfer.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of cuda_device_to_host_transfer.hpp
- * @date 2024-11-06
- * 
- */
-
 #include <xmipp4/cuda/compute/cuda_device_to_host_transfer.hpp>
 
 #include <xmipp4/cuda/compute/cuda_device_queue.hpp>

--- a/src/compute/cuda_device_to_host_transfer.cpp
+++ b/src/compute/cuda_device_to_host_transfer.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 #include <xmipp4/cuda/compute/cuda_device_to_host_transfer.hpp>
 

--- a/src/compute/cuda_error.cpp
+++ b/src/compute/cuda_error.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 // Based on: https://leimao.github.io/blog/Proper-CUDA-Error-Checking/
 

--- a/src/compute/cuda_error.cpp
+++ b/src/compute/cuda_error.cpp
@@ -54,4 +54,3 @@ void cuda_check(cudaError_t code,
 
 } // namespace compute
 } // namespace xmipp4
-

--- a/src/compute/cuda_error.cpp
+++ b/src/compute/cuda_error.cpp
@@ -18,16 +18,7 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 
-/**
- * @file cuda_error.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of cuda_error.hpp
- * @date 2024-11-17
- * 
- * Based on:
- * https://leimao.github.io/blog/Proper-CUDA-Error-Checking/
- * 
- */
+// Based on: https://leimao.github.io/blog/Proper-CUDA-Error-Checking/
 
 #include <xmipp4/cuda/compute/cuda_error.hpp>
 

--- a/src/compute/cuda_event.cpp
+++ b/src/compute/cuda_event.cpp
@@ -18,14 +18,6 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 
-/**
- * @file cuda_event.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of cuda_event.hpp
- * @date 2024-11-07
- * 
- */
-
 #include <xmipp4/cuda/compute/cuda_event.hpp>
 
 #include <xmipp4/cuda/compute/cuda_error.hpp>

--- a/src/compute/cuda_event.cpp
+++ b/src/compute/cuda_event.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 #include <xmipp4/cuda/compute/cuda_event.hpp>
 

--- a/src/compute/cuda_host_memory_allocator.cpp
+++ b/src/compute/cuda_host_memory_allocator.cpp
@@ -18,14 +18,6 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 
-/**
- * @file cuda_host_memory_allocator.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of cuda_host_memory_allocator.hpp
- * @date 2024-11-06
- * 
- */
-
 #include <xmipp4/cuda/compute/cuda_host_memory_allocator.hpp>
 
 #include "default_cuda_host_buffer.hpp"

--- a/src/compute/cuda_host_memory_allocator.cpp
+++ b/src/compute/cuda_host_memory_allocator.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 #include <xmipp4/cuda/compute/cuda_host_memory_allocator.hpp>
 

--- a/src/compute/cuda_host_to_device_transfer.cpp
+++ b/src/compute/cuda_host_to_device_transfer.cpp
@@ -18,14 +18,6 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 
-/**
- * @file cuda_host_to_device_transfer.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of cuda_host_to_device_transfer.hpp
- * @date 2024-11-06
- * 
- */
-
 #include <xmipp4/cuda/compute/cuda_host_to_device_transfer.hpp>
 
 #include <xmipp4/cuda/compute/cuda_device_queue.hpp>

--- a/src/compute/cuda_host_to_device_transfer.cpp
+++ b/src/compute/cuda_host_to_device_transfer.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 #include <xmipp4/cuda/compute/cuda_host_to_device_transfer.hpp>
 

--- a/src/compute/default_cuda_device_buffer.cpp
+++ b/src/compute/default_cuda_device_buffer.cpp
@@ -18,14 +18,6 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 
-/**
- * @file default_cuda_device_buffer.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of default_cuda_device_buffer.hpp
- * @date 2024-10-30
- * 
- */
-
 #include "default_cuda_device_buffer.hpp"
 
 #include <xmipp4/cuda/compute/allocator/cuda_memory_block.hpp>

--- a/src/compute/default_cuda_device_buffer.cpp
+++ b/src/compute/default_cuda_device_buffer.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 #include "default_cuda_device_buffer.hpp"
 

--- a/src/compute/default_cuda_device_buffer.hpp
+++ b/src/compute/default_cuda_device_buffer.hpp
@@ -20,14 +20,6 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 
-/**
- * @file default_cuda_device_buffer.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines the compute::default_cuda_device_buffer class
- * @date 2024-10-30
- * 
- */
-
 #include <xmipp4/cuda/compute/cuda_device_buffer.hpp>
 #include <xmipp4/cuda/compute/allocator/cuda_memory_allocator_delete.hpp>
 

--- a/src/compute/default_cuda_device_buffer.hpp
+++ b/src/compute/default_cuda_device_buffer.hpp
@@ -1,25 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
 #pragma once
-
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
-
 #include <xmipp4/cuda/compute/cuda_device_buffer.hpp>
 #include <xmipp4/cuda/compute/allocator/cuda_memory_allocator_delete.hpp>
 

--- a/src/compute/default_cuda_host_buffer.cpp
+++ b/src/compute/default_cuda_host_buffer.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 #include "default_cuda_host_buffer.hpp"
 

--- a/src/compute/default_cuda_host_buffer.cpp
+++ b/src/compute/default_cuda_host_buffer.cpp
@@ -18,14 +18,6 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 
-/**
- * @file default_cuda_host_buffer.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of default_cuda_host_buffer.hpp
- * @date 2024-10-30
- * 
- */
-
 #include "default_cuda_host_buffer.hpp"
 
 #include <xmipp4/cuda/compute/allocator/cuda_memory_block.hpp>

--- a/src/compute/default_cuda_host_buffer.hpp
+++ b/src/compute/default_cuda_host_buffer.hpp
@@ -20,14 +20,6 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 
-/**
- * @file default_cuda_host_buffer.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines the compute::default_cuda_host_buffer class
- * @date 2024-10-30
- * 
- */
-
 #include <xmipp4/core/compute/host_buffer.hpp>
 #include <xmipp4/cuda/compute/allocator/cuda_memory_allocator_delete.hpp>
 

--- a/src/compute/default_cuda_host_buffer.hpp
+++ b/src/compute/default_cuda_host_buffer.hpp
@@ -1,25 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
 #pragma once
-
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
-
 #include <xmipp4/core/compute/host_buffer.hpp>
 #include <xmipp4/cuda/compute/allocator/cuda_memory_allocator_delete.hpp>
 

--- a/src/cuda_plugin.cpp
+++ b/src/cuda_plugin.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 #include "cuda_plugin.hpp"
 

--- a/src/cuda_plugin.cpp
+++ b/src/cuda_plugin.cpp
@@ -18,14 +18,6 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 
-/**
- * @file cuda_plugin.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of cuda_plugin.hpp
- * @date 2024-10-30
- * 
- */
-
 #include "cuda_plugin.hpp"
 
 #include <xmipp4/cuda/compute/cuda_device_backend.hpp>

--- a/src/cuda_plugin.hpp
+++ b/src/cuda_plugin.hpp
@@ -1,25 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
 #pragma once
-
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
-
 
 #include <xmipp4/core/plugin.hpp>
 

--- a/src/cuda_plugin.hpp
+++ b/src/cuda_plugin.hpp
@@ -20,14 +20,6 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 
-/**
- * @file cuda_plugin.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Definition of the cuda_plugin class
- * @date 2024-10-26
- * 
- */
-
 
 #include <xmipp4/core/plugin.hpp>
 

--- a/src/cuda_plugin_hook.cpp
+++ b/src/cuda_plugin_hook.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 #include "cuda_plugin.hpp"
 

--- a/src/cuda_plugin_hook.cpp
+++ b/src/cuda_plugin_hook.cpp
@@ -18,14 +18,6 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 
-/**
- * @file cuda_plugin_hook.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Exports the entry point for this plugin.
- * @date 2024-10-30
- * 
- */
-
 #include "cuda_plugin.hpp"
 
 #include <xmipp4/core/platform/dynamic_shared_object.h>

--- a/tests/.clang-tidy
+++ b/tests/.clang-tidy
@@ -1,24 +1,2 @@
-#***************************************************************************
-# Authors:     Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-# 02111-1307  USA
-#
-#  All comments concerning this program package may be sent to the
-#  e-mail address 'xmipp@cnb.csic.es'
-# ***************************************************************************
-
 # Disable all checks in this folder.
 Checks: '-*'

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,25 +1,3 @@
-#***************************************************************************
-# Authors:     Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-# 02111-1307  USA
-#
-#  All comments concerning this program package may be sent to the
-#  e-mail address 'xmipp@cnb.csic.es'
-# ***************************************************************************
-
 cmake_minimum_required(VERSION 3.16)
 
 include(CTest)

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -1,25 +1,3 @@
-#***************************************************************************
-# Authors:     Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-# 02111-1307  USA
-#
-#  All comments concerning this program package may be sent to the
-#  e-mail address 'xmipp@cnb.csic.es'
-# ***************************************************************************
-
 cmake_minimum_required(VERSION 3.16)
 
 include(CTest)

--- a/tests/integration/src/test_load.cpp
+++ b/tests/integration/src/test_load.cpp
@@ -18,13 +18,6 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 
-/**
- * @file test_load.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Test that the plugin loads and registers.
- * @date 2024-10-30
- */
-
 
 #include <catch2/catch_test_macros.hpp>
 

--- a/tests/integration/src/test_load.cpp
+++ b/tests/integration/src/test_load.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 
 #include <catch2/catch_test_macros.hpp>

--- a/tests/unitary/CMakeLists.txt
+++ b/tests/unitary/CMakeLists.txt
@@ -1,25 +1,3 @@
-#***************************************************************************
-# Authors:     Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-# 02111-1307  USA
-#
-#  All comments concerning this program package may be sent to the
-#  e-mail address 'xmipp@cnb.csic.es'
-# ***************************************************************************
-
 cmake_minimum_required(VERSION 3.16)
 
 # Test excecutable name

--- a/tests/unitary/src/compute/allocator/test_cuda_memory_block.cpp
+++ b/tests/unitary/src/compute/allocator/test_cuda_memory_block.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 #include <xmipp4/cuda/compute/allocator/cuda_memory_block.hpp>
 

--- a/tests/unitary/src/compute/allocator/test_cuda_memory_block.cpp
+++ b/tests/unitary/src/compute/allocator/test_cuda_memory_block.cpp
@@ -18,14 +18,6 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 
-/**
- * @file test_cuda_memory_block.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Tests for cuda_memory_block.hpp
- * @date 2024-11-19
- * 
- */
-
 #include <xmipp4/cuda/compute/allocator/cuda_memory_block.hpp>
 
 #include <cstddef>

--- a/tests/unitary/src/compute/allocator/test_cuda_memory_block_pool.cpp
+++ b/tests/unitary/src/compute/allocator/test_cuda_memory_block_pool.cpp
@@ -18,14 +18,6 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 
-/**
- * @file test_cuda_memory_block_pool.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Tests for cuda_memory_block_pool.hpp
- * @date 2024-11-19
- * 
- */
-
 #include <xmipp4/cuda/compute/allocator/cuda_memory_block_pool.hpp>
 
 #include <cstddef>

--- a/tests/unitary/src/compute/allocator/test_cuda_memory_block_pool.cpp
+++ b/tests/unitary/src/compute/allocator/test_cuda_memory_block_pool.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 #include <xmipp4/cuda/compute/allocator/cuda_memory_block_pool.hpp>
 

--- a/tests/unitary/src/compute/allocator/test_cuda_memory_block_usage_tracker.cpp
+++ b/tests/unitary/src/compute/allocator/test_cuda_memory_block_usage_tracker.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 #include <xmipp4/cuda/compute/allocator/cuda_memory_block_usage_tracker.hpp>
 

--- a/tests/unitary/src/compute/allocator/test_cuda_memory_block_usage_tracker.cpp
+++ b/tests/unitary/src/compute/allocator/test_cuda_memory_block_usage_tracker.cpp
@@ -18,14 +18,6 @@
  *  e-mail address 'xmipp@cnb.csic.es'
  ***************************************************************************/
 
-/**
- * @file cuda_memory_block_usage_tracker.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Tests for cuda_memory_block_usage_tracker.hpp
- * @date 2024-12-09
- * 
- */
-
 #include <xmipp4/cuda/compute/allocator/cuda_memory_block_usage_tracker.hpp>
 
 #include <cstddef>


### PR DESCRIPTION
Also:
- Removed redundant doxygen file headers
- Removed double line breaks