### PR TITLE
Create CODEOWNERS file with default owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# global owners will be requested for
+# review when someone opens a pull request.
+*  @oierlauzi @martin-s-a @Ratolon


### PR DESCRIPTION
Add default code owners for the repository.
This will also allow dependabot to request review from code owners when opening a PR.